### PR TITLE
ELK stack vpc

### DIFF
--- a/tf-modules/elk-stack/main.tf
+++ b/tf-modules/elk-stack/main.tf
@@ -37,24 +37,46 @@ data "aws_ami" "ubuntu" {
   }
 }
 
+# module "vpc" {
+#   source = "../vpc"
 
-module "vpc" {
-  source = "../vpc"
+#   azs                  = ["${var.vpc_azs}"]
+#   cidr                 = "${var.vpc_cidr}"
+#   name_prefix          = "${var.name_prefix}"
+#   public_subnet_cidrs  = ["${var.vpc_public_subnet_cidrs}"]
+#   private_subnet_cidrs = ["${var.vpc_private_subnet_cidrs}"]
+#   region               = "${var.region}"
+#   extra_tags           = {}
+#   nat_count            = "${length(var.vpc_azs) % floor(max(var.elasticsearch_data_node_count, var.elasticsearch_master_node_count) + 1)}"
+# }
+# resource "aws_route53_zone_association" "e1c-net" {
+#   zone_id = "${var.route53_zone_id}"
+#   vpc_id  = "${module.vpc.vpc_id}"
+# }
 
-  azs                  = ["${var.vpc_azs}"]
-  cidr                 = "${var.vpc_cidr}"
+module "subnets" {
+  source               = "../subnets"
+  azs                  = "${var.vpc_azs}"
+  vpc_id               = "${var.vpc_id}"
   name_prefix          = "${var.name_prefix}"
-  public_subnet_cidrs  = ["${var.vpc_public_subnet_cidrs}"]
-  private_subnet_cidrs = ["${var.vpc_private_subnet_cidrs}"]
-  region               = "${var.region}"
-  extra_tags           = {}
-  nat_count            = "${length(var.vpc_azs) % floor(max(var.elasticsearch_data_node_count, var.elasticsearch_master_node_count) + 1)}"
+  public_subnet_cidrs  = "${var.vpc_public_subnet_cidrs}"
+  private_subnet_cidrs = "${var.vpc_private_subnet_cidrs}"
 }
 
+# Give internet to public subnets.
+resource "aws_route_table_association" "public-rta" {
+  count          = "${length(var.vpc_public_subnet_cidrs)}"
+  subnet_id      = "${element(module.subnets.public_ids, count.index)}"
+  route_table_id = "${var.vpc_route_table_id}"
+}
 
-resource "aws_route53_zone_association" "e1c-net" {
-  zone_id = "${var.route53_zone_id}"
-  vpc_id  = "${module.vpc.vpc_id}"
+module "nat-gateways" {
+  source             = "../nat-gateways"
+  vpc_id             = "${var.vpc_id}"
+  name_prefix        = "${var.name_prefix}"
+  nat_count          = "${length(var.vpc_azs) % floor(max(var.elasticsearch_data_node_count, var.elasticsearch_master_node_count) + 1)}"
+  public_subnet_ids  = ["${module.subnets.public_ids}"]
+  private_subnet_ids = ["${module.subnets.private_ids}"]
 }
 
 
@@ -63,13 +85,13 @@ module "elasticsearch" {
 
   name_prefix               = "${var.name_prefix}"
   region                    = "${var.region}"
-  vpc_id                    = "${module.vpc.vpc_id}"
+  vpc_id                    = "${var.vpc_id}"
   vpc_azs                   = ["${var.vpc_azs}"]
   route53_zone_id           = "${var.route53_zone_id}"
   key_name                  = "${aws_key_pair.elk-key.key_name}"
   vpc_public_subnet_cidrs   = ["${var.vpc_public_subnet_cidrs}"]
   vpc_private_subnet_cidrs  = ["${var.vpc_private_subnet_cidrs}"]
-  vpc_private_subnet_ids    = ["${module.vpc.private_subnet_ids}"]
+  vpc_private_subnet_ids    = ["${module.subnets.private_ids}"]
   node_ami                  = "${data.aws_ami.ubuntu.id}"
   data_node_count           = "${var.elasticsearch_data_node_count}"
   data_node_ebs_size        = "${var.elasticsearch_data_node_ebs_size}"
@@ -86,11 +108,11 @@ module "kibana" {
   source = "../kibana"
 
   name_prefix          = "${var.name_prefix}"
-  vpc_id               = "${module.vpc.vpc_id}"
+  vpc_id               = "${var.vpc_id}"
   vpc_azs              = ["${var.vpc_azs}"]
   route53_zone_id      = "${var.route53_zone_id}"
   kibana_dns_name      = "${var.kibana_dns_name}"
-  subnet_ids           = ["${module.vpc.public_subnet_ids}"]
+  subnet_ids           = ["${module.subnets.public_ids}"]
   key_name             = ""
   ami                  = ""
   instance_type        = ""
@@ -104,8 +126,8 @@ module "logstash-kibana" {
   source = "../logstash"
 
   name_prefix              = "${var.name_prefix}-kibana"
-  vpc_id                   = "${module.vpc.vpc_id}"
-  subnet_ids               = ["${module.vpc.public_subnet_ids}"]
+  vpc_id                   = "${var.vpc_id}"
+  subnet_ids               = ["${module.subnets.public_ids}"]
   vpc_azs                  = ["${var.vpc_azs}"]
   route53_zone_id          = "${var.route53_zone_id}"
   logstash_dns_name        = "${var.logstash_dns_name}"
@@ -138,7 +160,7 @@ resource "aws_instance" "control-instance" {
   count                       = "${var.deploy_control_instance}"
   ami                         = "${data.aws_ami.ubuntu.id}"
   instance_type               = "t2.nano"
-  subnet_id                   = "${module.vpc.public_subnet_ids[0]}"
+  subnet_id                   = "${module.subnets.public_ids[0]}"
   vpc_security_group_ids      = ["${aws_security_group.control-instance-sg.id}"]
   key_name                    = "${aws_key_pair.elk-key.key_name}"
   associate_public_ip_address = true
@@ -152,7 +174,7 @@ resource "aws_instance" "control-instance" {
 resource "aws_security_group" "control-instance-sg" {
   count       = "${var.deploy_control_instance}"
   name        = "${var.name_prefix}-control-instance-sg"
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id      = "${var.vpc_id}"
   description = "Allow SSH, ICMP, Elasticsearch TCP, Elasticsearch HTTP, and everything outbound."
 
   ingress {
@@ -198,15 +220,6 @@ output "elasticsearch_internal_elb_dns" {
 #   value = "${module.logstash-kibana.kibana_elb_dns}"
 # }
 
-//VPC ID
-output "vpc_id" {
-  value = "${module.vpc.vpc_id}"
-}
-
-//Public subnte IDS
-output "public_subnet_ids" {
-  value = ["${module.vpc.public_subnet_ids}"]
-}
 
 //Running this command will setup SOCKS proxy to VPC through control instance.
 output "socket_cmd" {

--- a/tf-modules/elk-stack/main.tf
+++ b/tf-modules/elk-stack/main.tf
@@ -70,7 +70,7 @@ module "elasticsearch" {
   vpc_public_subnet_cidrs   = ["${var.vpc_public_subnet_cidrs}"]
   vpc_private_subnet_cidrs  = ["${var.vpc_private_subnet_cidrs}"]
   vpc_private_subnet_ids    = ["${module.vpc.private_subnet_ids}"]
-  node_ami                  = "${data.aws_ami.ubuntu.id}" # "${var.ami}"
+  node_ami                  = "${data.aws_ami.ubuntu.id}"
   data_node_count           = "${var.elasticsearch_data_node_count}"
   data_node_ebs_size        = "${var.elasticsearch_data_node_ebs_size}"
   data_node_snapshot_ids    = ["${var.elasticsearch_data_node_snapshot_ids}"]
@@ -136,7 +136,7 @@ resource "aws_key_pair" "elk-key" {
 
 resource "aws_instance" "control-instance" {
   count                       = "${var.deploy_control_instance}"
-  ami                         = "${data.aws_ami.ubuntu.id}" # "${var.ami}"
+  ami                         = "${data.aws_ami.ubuntu.id}"
   instance_type               = "t2.nano"
   subnet_id                   = "${module.vpc.public_subnet_ids[0]}"
   vpc_security_group_ids      = ["${aws_security_group.control-instance-sg.id}"]

--- a/tf-modules/elk-stack/main.tf
+++ b/tf-modules/elk-stack/main.tf
@@ -175,7 +175,7 @@ resource "aws_security_group" "control-instance-sg" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
 }
 
 //Control instance public IP address. If list is empty, control instance wasn't deployed.
@@ -188,12 +188,12 @@ output "elasticsearch_internal_elb_dns" {
   value = "${module.elasticsearch.elb_dns}"
 }
 
-# //Logstash Load Balancer DNS. 
+# //Logstash Load Balancer DNS.
 # output "logstash_elb_dns" {
 #   value = "${module.logstash-kibana.logstash_elb_dns}"
 # }
 
-# //Kibana Load Balancer DNS. 
+# //Kibana Load Balancer DNS.
 # output "kibana_elb_dns" {
 #   value = "${module.logstash-kibana.kibana_elb_dns}"
 # }

--- a/tf-modules/elk-stack/variables.tf
+++ b/tf-modules/elk-stack/variables.tf
@@ -14,9 +14,12 @@ variable "region" {
   description = "Region to deploy ELK stack in"
 }
 
-variable "vpc_cidr" {
-  description = "The CIDR range of the VPC"
-  default     = "172.16.0.0/21"
+variable "vpc_id" {
+  description = "VPC ID for the ELK stack"
+}
+
+variable "vpc_route_table_id" {
+  description = "ID of the route table, with which created subnets will be associated with"
 }
 
 variable "vpc_azs" {

--- a/tf-modules/kibana/main.tf
+++ b/tf-modules/kibana/main.tf
@@ -16,7 +16,7 @@ resource "aws_elb" "kibana-elb" {
   name = "${var.name_prefix}-kibana-elb"
   subnets       = ["${var.subnet_ids}"]
   security_groups = ["${aws_security_group.kibana-elb-sg.id}"]
-  
+
   listener {
     instance_port = 5601
     instance_protocol = "http"
@@ -119,7 +119,7 @@ resource "aws_security_group" "kibana-elb-sg" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   ingress {
     from_port   = -1
     to_port     = -1

--- a/tf-modules/kibana/main.tf
+++ b/tf-modules/kibana/main.tf
@@ -16,7 +16,7 @@ resource "aws_elb" "kibana-elb" {
   name = "${var.name_prefix}-kibana-elb"
   subnets       = ["${var.subnet_ids}"]
   security_groups = ["${aws_security_group.kibana-elb-sg.id}"]
-
+  
   listener {
     instance_port = 5601
     instance_protocol = "http"
@@ -119,7 +119,7 @@ resource "aws_security_group" "kibana-elb-sg" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
+  
   ingress {
     from_port   = -1
     to_port     = -1

--- a/tf-modules/nat-gateways/main.tf
+++ b/tf-modules/nat-gateways/main.tf
@@ -7,5 +7,26 @@ resource "aws_eip" "nat" {
 resource "aws_nat_gateway" "nat" {
   count         = "${var.nat_count}"
   allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
-  subnet_id     = "${var.subnet_ids[count.index]}"
+  subnet_id     = "${var.public_subnet_ids[count.index]}"
 }
+
+
+# Route tables. One per NAT gateway.
+resource "aws_route_table" "private" {
+  count  = "${var.nat_count}"
+  vpc_id = "${var.vpc_id}"
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = "${element(aws_nat_gateway.nat.*.id, count.index)}"
+  }
+
+  tags = "${merge(map("Name", "${var.name_prefix}-private-${format("%02d", count.index)}"), "${var.extra_tags}")}"
+}
+
+resource "aws_route_table_association" "private-rta" {
+  count          = "${var.nat_count}"
+  subnet_id      = "${var.private_subnet_ids[count.index]}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+}
+

--- a/tf-modules/nat-gateways/variables.tf
+++ b/tf-modules/nat-gateways/variables.tf
@@ -1,8 +1,26 @@
-variable "subnet_ids" {
-  description = "Public subnet IDs where to place the gateways"
-  type = "list"
+variable "vpc_id" {
+  description = "VPC ID where route tables will be placed in"
+}
+
+variable "name_prefix" {
+  description = "Project name. It will be prepended to route tables."
 }
 
 variable "nat_count" {
   description = "How many NAT gateways to setup"
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs where to place the gateways"
+  type = "list"
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the route table associations, i.e subntes that will get internet acess"
+  type = "list"
+}
+
+variable "extra_tags" {
+  default = {}
+  description = "Any extra tags to assign to route tables"
 }

--- a/tf-modules/subnets/main.tf
+++ b/tf-modules/subnets/main.tf
@@ -1,0 +1,26 @@
+/**
+ *## Subnets creation
+ *
+ * This module can create public and private subnets while interleaving them
+ * throughout supplied availiability zones.
+ *
+ */
+
+
+resource "aws_subnet" "public" {
+  count             = "${length(var.public_subnet_cidrs)}"
+  vpc_id            = "${var.vpc_id}"
+  cidr_block        = "${var.public_subnet_cidrs[count.index]}"
+  availability_zone = "${element(var.azs, count.index)}"
+  tags              = "${merge(map("Name", "${var.name_prefix}-public-${format("%02d", count.index)}-${element(var.azs, count.index)}"), "${var.extra_tags}")}"
+}
+
+resource "aws_subnet" "private" {
+  count                   = "${length(var.private_subnet_cidrs)}"
+  vpc_id                  = "${var.vpc_id}"
+  cidr_block              = "${var.private_subnet_cidrs[count.index]}"
+  availability_zone       = "${element(var.azs, count.index)}"
+  map_public_ip_on_launch = false
+  tags                    = "${merge(map("Name", "${var.name_prefix}-private-${format("%02d", count.index)}-${element(var.azs, count.index)}"), "${var.extra_tags}")}"
+}
+

--- a/tf-modules/subnets/output.tf
+++ b/tf-modules/subnets/output.tf
@@ -1,0 +1,10 @@
+//List of public subnet ids
+output "public_ids" {
+  value = ["${aws_subnet.public.*.id}"]
+}
+
+//List of private subnet ids
+output "private_ids" {
+  value = ["${aws_subnet.private.*.id}"]
+}
+

--- a/tf-modules/subnets/variables.tf
+++ b/tf-modules/subnets/variables.tf
@@ -1,0 +1,27 @@
+variable "name_prefix" {
+  description = "Project name. It will be prepended to all subnets"
+}
+
+variable "vpc_id" {
+  description = "VPC ID where subnets will be created"
+}
+
+variable "public_subnet_cidrs" {
+  description = "A list of public subnet CIDRs"
+  default = []
+}
+
+variable "private_subnet_cidrs" {
+  description = "A list of private subnet CIDRs. Should not be higher than public subnets count"
+  default = []
+}
+
+variable "azs" {
+  type = "list"
+  description = "A list of Availaiblity Zones in the region"
+}
+
+variable "extra_tags" {
+  description = "Extra tags that will be added to Subnets"
+  default = {}
+}

--- a/tf-modules/vpc/main.tf
+++ b/tf-modules/vpc/main.tf
@@ -70,4 +70,5 @@ module "nat-gateways" {
   nat_count          = "${var.nat_count}"
   public_subnet_ids  = ["${module.subnets.public_ids}"]
   private_subnet_ids = ["${module.subnets.private_ids}"]
+  extra_tags         = "${var.extra_tags}"
 }

--- a/tf-modules/vpc/main.tf
+++ b/tf-modules/vpc/main.tf
@@ -12,12 +12,6 @@ resource "aws_vpc" "main" {
   tags = "${merge(map("Name", "${var.name_prefix}-vpc"), "${var.extra_tags}")}"
 }
 
-resource "aws_internet_gateway" "main" {
-  vpc_id = "${aws_vpc.main.id}"
-
-  tags = "${merge(map("Name", "${var.name_prefix}-igw"), "${var.extra_tags}")}"
-}
-
 resource "aws_vpc_dhcp_options" "main" {
   domain_name         = "${var.region}.compute.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
@@ -30,66 +24,50 @@ resource "aws_vpc_dhcp_options_association" "main" {
   dhcp_options_id = "${aws_vpc_dhcp_options.main.id}"
 }
 
-resource "aws_subnet" "public" {
-  count             = "${length(var.public_subnet_cidrs)}"
-  vpc_id            = "${aws_vpc.main.id}"
-  cidr_block        = "${var.public_subnet_cidrs[count.index]}"
-  availability_zone = "${var.azs[count.index]}"
-  tags              = "${merge(map("Name", "${var.name_prefix}-public-${var.azs[count.index]}"), "${var.extra_tags}")}"
+module "subnets" {
+  source               = "../subnets"
+  azs                  = "${var.azs}"
+  vpc_id               = "${aws_vpc.main.id}"
+  name_prefix          = "${var.name_prefix}"
+  public_subnet_cidrs  = "${var.public_subnet_cidrs}"
+  private_subnet_cidrs = "${var.private_subnet_cidrs}"
+  extra_tags           = "${var.extra_tags}"
 }
 
-resource "aws_subnet" "private" {
-  count                   = "${length(var.private_subnet_cidrs)}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${var.private_subnet_cidrs[count.index]}"
-  availability_zone       = "${var.azs[count.index]}"
-  map_public_ip_on_launch = false
-  tags                    = "${merge(map("Name", "${var.name_prefix}-private-${var.azs[count.index]}"), "${var.extra_tags}")}"
+
+## Internet Gateway - provide internet access to public subnets.
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = "${aws_vpc.main.id}"
+
+  tags = "${merge(map("Name", "${var.name_prefix}-igw"), "${var.extra_tags}")}"
 }
 
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.main.id}"
 
-  tags = "${merge(map("Name", "${var.name_prefix}-public"), "${var.extra_tags}")}"
-}
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.main.id}"
+  }
 
-resource "aws_route" "public_internet_gateway" {
-  route_table_id         = "${aws_route_table.public.id}"
-  gateway_id             = "${aws_internet_gateway.main.id}"
-  destination_cidr_block = "0.0.0.0/0"
+  tags = "${merge(map("Name", "${var.name_prefix}-public"), "${var.extra_tags}")}"
 }
 
 resource "aws_route_table_association" "public-rta" {
   count          = "${length(var.public_subnet_cidrs)}"
-  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
+  subnet_id      = "${element(module.subnets.public_ids, count.index)}"
   route_table_id = "${aws_route_table.public.id}"
 }
 
 
-## NAT Gateways - provide internet access to instances in private subnets.
+## NAT Gateways - provide internet access to private subnets.
 
 module "nat-gateways" {
-  source     = "../nat-gateways"
-  nat_count  = "${var.nat_count}"
-  subnet_ids = ["${aws_subnet.public.*.id}"]
+  source             = "../nat-gateways"
+  vpc_id             = "${aws_vpc.main.id}"
+  name_prefix        = "${var.name_prefix}"
+  nat_count          = "${var.nat_count}"
+  public_subnet_ids  = ["${module.subnets.public_ids}"]
+  private_subnet_ids = ["${module.subnets.private_ids}"]
 }
-
-# Route tables. One per private subnet.
-resource "aws_route_table" "private" {
-  count  = "${var.nat_count}"
-  vpc_id = "${aws_vpc.main.id}"
-
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(module.nat-gateways.ids, count.index)}"
-  }
-
-  tags = "${merge(map("Name", "${var.name_prefix}-private-${element(var.azs, count.index)}"), "${var.extra_tags}")}"
-}
-
-resource "aws_route_table_association" "private-rta" {
-  count          = "${var.nat_count}"
-  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
-}
-

--- a/tf-modules/vpc/main.tf
+++ b/tf-modules/vpc/main.tf
@@ -3,7 +3,7 @@
  *
  * This module takes care of VPC deployment. Scenarios 1 and 2 are possible with
  * this module: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenarios.html
- * 
+ *
  */
 resource "aws_vpc" "main" {
   cidr_block           = "${var.cidr}"
@@ -72,7 +72,7 @@ module "nat-gateways" {
   source     = "../nat-gateways"
   nat_count  = "${var.nat_count}"
   subnet_ids = ["${aws_subnet.public.*.id}"]
-}  
+}
 
 # Route tables. One per private subnet.
 resource "aws_route_table" "private" {

--- a/tf-modules/vpc/outputs.tf
+++ b/tf-modules/vpc/outputs.tf
@@ -5,12 +5,12 @@ output "vpc_id" {
 
 //List of private subnet ids. None created if list is empty.
 output "private_subnet_ids" {
-  value = ["${aws_subnet.private.*.id}"]
+  value = ["${module.subnets.private_ids}"]
 }
 
 //List of public subnet ids
 output "public_subnet_ids" {
-  value = ["${aws_subnet.public.*.id}"]
+  value = ["${module.subnets.public_ids}"]
 }
 
 // Route table id associated with public subnets

--- a/tf-modules/vpc/variables.tf
+++ b/tf-modules/vpc/variables.tf
@@ -1,5 +1,5 @@
 variable "name_prefix" {
-  description = "Project name. It will pbe prepended to all resources."
+  description = "Project name. It will be prepended to all resources."
 }
 
 variable "region" {
@@ -22,12 +22,12 @@ variable "private_subnet_cidrs" {
 
 variable "azs" {
   type = "list"
-  description = "A list of Availaiblity zones in the region"
+  description = "A list of Availaiblity Zones in the region"
 }
 
 variable "extra_tags" {
   description = "Extra tags that will be added to VPC, DHCP Options, Internet Gateway, Subnets and Routing Table."
-  default = {} 
+  default = {}
 }
 
 variable "nat_count" {


### PR DESCRIPTION
* Removed VPC creation from `elk-stack` module, so now there two extra variables: `vpc_id` and `vpc_route_table_id`
* Moved out private and public subnets creation into it's own submodule
* Moved route tables creation for NATs into the `nat-gateway` module