### PR TITLE
Addition of Basic Authentication for Elasticsearch

### DIFF
--- a/tf-modules/elasticsearch/data-nodes.tf
+++ b/tf-modules/elasticsearch/data-nodes.tf
@@ -85,7 +85,8 @@ data "template_file" "data-node-setup" {
     credstash_ca_cert_name     = "${var.name_prefix}-logstash-ca-cert"
     credstash_client_cert_name = "${var.name_prefix}-logstash-client-cert"
     credstash_client_key_name  = "${var.name_prefix}-logstash-client-key"
-    credstash_context          = "env=${var.name_prefix} service=elk"
+    credstash_context          = "env=${var.name_prefix}"
+    is_master_node             = false
     logstash_beats_address     = "${var.logstash_beats_address}"
     extra_setup_snippet        = <<EXTRA_SETUP
 ${var.deploy_proxy ? data.template_file.proxy-setup.rendered : ""}
@@ -101,7 +102,7 @@ data "template_file" "proxy-setup" {
   vars {
     credstash_install_snippet = "${var.credstash_install_snippet}"
     credstash_get_cmd         = "${var.credstash_get_cmd}"
-    credstash_context         = "env=${var.name_prefix} service=elk"
+    credstash_context         = "env=${var.name_prefix}"
     nginx_username_key        = "${var.name_prefix}-elasticsearch-basic-auth-username"
     nginx_password_key        = "${var.name_prefix}-elasticsearch-basic-auth-password"
   }

--- a/tf-modules/elasticsearch/data/curator-setup.tpl.sh
+++ b/tf-modules/elasticsearch/data/curator-setup.tpl.sh
@@ -1,0 +1,77 @@
+# Install curator (will only run on the active master)
+
+pip install elasticsearch-curator
+useradd -r curator
+mkdir /var/log/curator/
+chown curator:curator /var/log/curator
+mkdir /etc/curator
+TMP_CRON=$(mktemp -t "curator-cron-job-XXXXXX.txt")
+echo '30 1 * * * /usr/local/bin/curator --config /etc/curator/config.yaml /etc/curator/actionfile.yaml' > $TMP_CRON
+crontab -u curator $TMP_CRON
+
+cat <<EOF > /etc/curator/config.yaml
+client:
+  hosts:
+    - localhost
+  port: 9200
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: True
+
+logging:
+  loglevel: INFO
+  logfile: /var/log/curator/curator.log
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']
+EOF
+
+cat <<EOF > /etc/curator/actionfile.yaml
+actions:
+  1:
+    action: delete_indices
+    description: >-
+      Delete indices older than ${index_retention_period} days (based on index name), for filebeat-
+      prefixed indices. Ignore the error if the filter does not result in an
+      actionable list of indices (ignore_empty_list) and exit cleanly.
+    options:
+      ignore_empty_list: True
+      timeout_override:
+      continue_if_exception: False
+      disable_action: ${index_retention_period == 0 ? "True" : "False"}
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: '^([a-z]+-)+'
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: ${index_retention_period}
+      exclude:
+${extra_curator_actions}
+EOF
+
+
+cat <<EOF > /etc/filebeat/prospectors/curator.yaml
+filebeat.prospectors:
+- input_type: log
+  paths:
+    - '/var/log/curator/*.log'
+  fields_under_root: true
+  fields:
+    index_prefix: elk
+    log_info:
+      origin: aws
+      source: curator
+      formats:
+        - curator
+      transport: filebeat
+EOF

--- a/tf-modules/elasticsearch/data/nginx-setup.tpl.sh
+++ b/tf-modules/elasticsearch/data/nginx-setup.tpl.sh
@@ -1,0 +1,54 @@
+apt-get install -y nginx
+BASIC_AUTH_USERNAME="$(${credstash_get_cmd} ${nginx_username_key} ${credstash_context})"
+BASIC_AUTH_PASSWORD="$(${credstash_get_cmd} ${nginx_password_key} ${credstash_context})"
+echo -n "$BASIC_AUTH_USERNAME:" > /etc/nginx/.htpasswd
+openssl passwd -apr1 "$BASIC_AUTH_PASSWORD" >> /etc/nginx/.htpasswd
+LOCAL_DNS=$(ec2metadata --local-hostname)
+
+cat <<EOF > /etc/nginx/sites-available/default
+server {
+    listen 9201;
+    server_name $LOCAL_DNS;
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log info;
+    location / {
+        proxy_pass http://localhost:9200;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        auth_basic "Restricted Space";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+    }
+}
+EOF
+service nginx reload
+
+
+cat <<EOF > /etc/filebeat/prospectors/nginx.yaml
+filebeat.prospectors:
+- input_type: log
+  paths:
+    - '/var/log/nginx/access.log'
+  fields_under_root: true
+  fields:
+    index_prefix: elk
+    log_info:
+      origin: aws
+      source: elasticsearch-proxy
+      formats:
+        - nginx_access
+      transport: filebeat
+- input_type: log
+  paths:
+    - '/var/log/nginx/error.log'
+  fields_under_root: true
+  fields:
+    index_prefix: elk
+    log_info:
+      origin: aws
+      source: elasticsearch-proxy
+      formats:
+        - nginx_error
+      transport: filebeat
+EOF

--- a/tf-modules/elasticsearch/data/setup.tpl.sh
+++ b/tf-modules/elasticsearch/data/setup.tpl.sh
@@ -46,9 +46,9 @@ systemctl start elasticsearch.service
 
 mkdir -p /etc/beats/ssl/
 
-${credstash_get_cmd} -n ${credstash_ca_cert_name} > /etc/beats/ssl/ca.crt
-${credstash_get_cmd} -n ${credstash_client_cert_name} > /etc/beats/ssl/client.crt
-${credstash_get_cmd} -n ${credstash_client_key_name} > /etc/beats/ssl/client.key
+${credstash_get_cmd} -n ${credstash_ca_cert_name} ${credstash_context} > /etc/beats/ssl/ca.crt
+${credstash_get_cmd} -n ${credstash_client_cert_name} ${credstash_context} > /etc/beats/ssl/client.crt
+${credstash_get_cmd} -n ${credstash_client_key_name} ${credstash_context} > /etc/beats/ssl/client.key
 
 
 ## Setup Filebeat

--- a/tf-modules/elasticsearch/data/setup.tpl.sh
+++ b/tf-modules/elasticsearch/data/setup.tpl.sh
@@ -40,8 +40,6 @@ systemctl daemon-reload
 systemctl enable elasticsearch.service
 systemctl start elasticsearch.service
 
-${extra_setup_snippet}
-
 ## ============
 ## Setup Beats
 ## ============
@@ -58,7 +56,10 @@ ${credstash_get_cmd} -n ${credstash_client_key_name} > /etc/beats/ssl/client.key
 
 apt-get install -y filebeat
 
+mkdir /etc/filebeat/prospectors/
+
 cat <<EOF > /etc/filebeat/filebeat.yml
+filebeat.config_dir: '/etc/filebeat/prospectors/'
 filebeat.prospectors:
 - input_type: log
   paths:
@@ -164,67 +165,5 @@ systemctl enable metricbeat.service
 systemctl start metricbeat.service
 
 
-# Exit if curator is deployed elsewhere.
+${extra_setup_snippet}
 
-(test "${is_master_node}" != "true" || test "${deploy_curator}" != "true") && exit 0;
-
-# Install curator (will only run on the active master)
-
-pip install elasticsearch-curator
-useradd -r curator
-mkdir /var/log/curator/
-chown curator:curator /var/log/curator
-mkdir /etc/curator
-TMP_CRON=$(mktemp -t "curator-cron-job-XXXXXX.txt")
-echo '30 1 * * * /usr/local/bin/curator --config /etc/curator/config.yaml /etc/curator/actionfile.yaml' > $TMP_CRON
-crontab -u curator $TMP_CRON
-
-cat <<EOF > /etc/curator/config.yaml
-client:
-  hosts:
-    - localhost
-  port: 9200
-  url_prefix:
-  use_ssl: False
-  certificate:
-  client_cert:
-  client_key:
-  ssl_no_validate: False
-  http_auth:
-  timeout: 30
-  master_only: True
-
-logging:
-  loglevel: INFO
-  logfile: /var/log/curator/curator.log
-  logformat: default
-  blacklist: ['elasticsearch', 'urllib3']
-EOF
-
-cat <<EOF > /etc/curator/actionfile.yaml
-actions:
-  1:
-    action: delete_indices
-    description: >-
-      Delete indices older than ${index_retention_period} days (based on index name), for filebeat-
-      prefixed indices. Ignore the error if the filter does not result in an
-      actionable list of indices (ignore_empty_list) and exit cleanly.
-    options:
-      ignore_empty_list: True
-      timeout_override:
-      continue_if_exception: False
-      disable_action: ${index_retention_period == 0 ? "True" : "False"}
-    filters:
-    - filtertype: pattern
-      kind: prefix
-      value: '^([a-z]+-)+'
-      exclude:
-    - filtertype: age
-      source: name
-      direction: older
-      timestring: '%Y.%m.%d'
-      unit: days
-      unit_count: ${index_retention_period}
-      exclude:
-${extra_curator_actions}
-EOF

--- a/tf-modules/elasticsearch/iam.tf
+++ b/tf-modules/elasticsearch/iam.tf
@@ -26,7 +26,7 @@ module "credstash-grant" {
   source            = "../credstash-grant"
   kms_key_arn       = "${var.credstash_kms_key_arn}"
   reader_policy_arn = "${var.credstash_reader_policy_arn}"
-  reader_context    = "env=${var.name_prefix} service=elk"
+  reader_context    = "env=${var.name_prefix}"
   roles_count       = "${var.master_node_count + var.data_node_count}"
   roles_arns        = ["${concat(aws_iam_role.master-node-role.*.arn, aws_iam_role.data-node-role.*.arn)}"]
   roles_names       = ["${concat(aws_iam_role.master-node-role.*.name, aws_iam_role.data-node-role.*.name)}"]

--- a/tf-modules/elasticsearch/iam.tf
+++ b/tf-modules/elasticsearch/iam.tf
@@ -26,6 +26,7 @@ module "credstash-grant" {
   source            = "../credstash-grant"
   kms_key_arn       = "${var.credstash_kms_key_arn}"
   reader_policy_arn = "${var.credstash_reader_policy_arn}"
+  reader_context    = "env=${var.name_prefix} service=elk"
   roles_count       = "${var.master_node_count + var.data_node_count}"
   roles_arns        = ["${concat(aws_iam_role.master-node-role.*.arn, aws_iam_role.data-node-role.*.arn)}"]
   roles_names       = ["${concat(aws_iam_role.master-node-role.*.name, aws_iam_role.data-node-role.*.name)}"]

--- a/tf-modules/elasticsearch/master-nodes.tf
+++ b/tf-modules/elasticsearch/master-nodes.tf
@@ -90,6 +90,8 @@ data "template_file" "master-node-setup" {
     credstash_ca_cert_name     = "${var.name_prefix}-logstash-ca-cert"
     credstash_client_cert_name = "${var.name_prefix}-logstash-client-cert"
     credstash_client_key_name  = "${var.name_prefix}-logstash-client-key"
+    credstash_context          = "env=${var.name_prefix}"
+    is_master_node             = true
     logstash_beats_address     = "${var.logstash_beats_address}"
     extra_setup_snippet        = <<EXTRA_SETUP
 ${var.deploy_curator ? data.template_file.curator-setup.rendered : ""}

--- a/tf-modules/elasticsearch/master-nodes.tf
+++ b/tf-modules/elasticsearch/master-nodes.tf
@@ -91,11 +91,21 @@ data "template_file" "master-node-setup" {
     credstash_client_cert_name = "${var.name_prefix}-logstash-client-cert"
     credstash_client_key_name  = "${var.name_prefix}-logstash-client-key"
     logstash_beats_address     = "${var.logstash_beats_address}"
-    is_master_node             = "true"
-    deploy_curator             = "${var.deploy_curator}"
-    index_retention_period     = "${var.index_retention_period}"
-    extra_curator_actions      = "${var.extra_curator_actions}"
-    extra_setup_snippet        = "${var.extra_setup_snippet}"
+    extra_setup_snippet        = <<EXTRA_SETUP
+${var.deploy_curator ? data.template_file.curator-setup.rendered : ""}
+
+${var.extra_setup_snippet}
+EXTRA_SETUP
+  }
+}
+
+
+data "template_file" "curator-setup" {
+  template = "${file("${path.module}/data/curator-setup.tpl.sh")}"
+
+  vars {
+    index_retention_period = "${var.index_retention_period}"
+    extra_curator_actions  = "${var.extra_curator_actions}"
   }
 }
 

--- a/tf-modules/elasticsearch/networking.tf
+++ b/tf-modules/elasticsearch/networking.tf
@@ -50,6 +50,13 @@ resource "aws_security_group" "elasticsearch-api-sg" {
     protocol        = "tcp"
     security_groups = ["${aws_security_group.elasticsearch-elb-sg.id}"]
   }
+
+  ingress {
+    from_port       = 9201
+    to_port         = 9201
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.elasticsearch-elb-sg.id}"]
+  }
 }
 
 resource "aws_security_group" "elasticsearch-elb-sg" {
@@ -65,7 +72,14 @@ resource "aws_security_group" "elasticsearch-elb-sg" {
     from_port   = 9200
     to_port     = 9200
     protocol    = "tcp"
-    cidr_blocks = ["${concat(data.aws_subnet.public.*.cidr_block, var.extra_elb_ingress_cidrs)}"]
+    cidr_blocks = ["${data.aws_subnet.public.*.cidr_block}"]
+  }
+
+  ingress {
+    from_port   = 9201
+    to_port     = 9201
+    protocol    = "tcp"
+    cidr_blocks = ["${var.auth_elb_ingress_cidrs}"]
   }
 
   egress {

--- a/tf-modules/elasticsearch/variables.tf
+++ b/tf-modules/elasticsearch/variables.tf
@@ -102,6 +102,11 @@ variable "deploy_curator" {
   description = "Should a curator be installed and enabled on all master eligible nodes. If enabled it will only run on currently elected master."
 }
 
+variable "deploy_proxy" {
+  default = false
+  description = "Should a reverse proxy with Basic Authentication be setup for ES API on port 9201."
+}
+
 variable "index_retention_period" {
   default = 60
   description = "Age of Elasticsearch indices in days before they will be considered old and be pruned by the curator. Set to 0 in order to disable."

--- a/tf-modules/elasticsearch/variables.tf
+++ b/tf-modules/elasticsearch/variables.tf
@@ -70,9 +70,9 @@ variable "extra_elb_sg_ids" {
   description = "Extra Security Group IDs that will be added to Elasticsearch API Load Balancer"
 }
 
-variable "extra_elb_ingress_cidrs" {
+variable "auth_elb_ingress_cidrs" {
   default = []
-  description = "Extra CIDRs that are allowed to access Elasticsearch API. By default only CIDR from `public_subnet_ids` are allowed"
+  description = "CIDRs that are allowed to access Elasticsearch API over HTTPS on port 9201 with BasicAuth."
 }
 
 variable "extra_setup_snippet" {
@@ -130,4 +130,9 @@ variable "credstash_install_snippet" {
 
 variable "credstash_get_cmd" {
   description = "Credstash get command with region and table values set."
+}
+
+variable "elasticsearch_dns_ssl_name" {
+  default = ""
+  description = "DNS name for Elasticsearch endpoint SSL. An SSL certificate is expected to be present in ACM for this domain. If left empty 'elasticsearch_dns_name' will be checked instead."
 }

--- a/tf-modules/elk-stack/main.tf
+++ b/tf-modules/elk-stack/main.tf
@@ -73,8 +73,10 @@ module "elasticsearch" {
   public_subnet_ids           = ["${var.private_subnet_ids}"]
   private_subnet_ids          = ["${var.private_subnet_ids}"]
   extra_sg_ids                = ["${aws_security_group.ssh.id}"]
+  auth_elb_ingress_cidrs      = ["${var.elasticsearch_auth_elb_ingress_cidrs}"]
   node_ami                    = "${data.aws_ami.ubuntu.id}"
   elasticsearch_dns_name      = "${var.elasticsearch_dns_name}"
+  elasticsearch_dns_ssl_name  = "${var.elasticsearch_dns_ssl_name}"
   data_node_count             = "${var.elasticsearch_data_node_count}"
   data_node_ebs_size          = "${var.elasticsearch_data_node_ebs_size}"
   data_node_snapshot_ids      = ["${var.elasticsearch_data_node_snapshot_ids}"]
@@ -88,6 +90,7 @@ module "elasticsearch" {
   credstash_reader_policy_arn = "${var.credstash_reader_policy_arn}"
   credstash_install_snippet   = "${var.credstash_install_snippet}"
   credstash_get_cmd           = "${var.credstash_get_cmd}"
+  deploy_proxy                = "${var.elasticsearch_deploy_proxy}"
   logstash_beats_address      = "${var.logstash_dns_name}:5044"
 }
 
@@ -95,23 +98,23 @@ module "elasticsearch" {
 module "kibana" {
   source = "../kibana"
 
-  name_prefix          = "${var.name_prefix}"
-  vpc_id               = "${var.vpc_id}"
-  route53_zone_id      = "${var.route53_zone_id}"
-  kibana_dns_name      = "${var.kibana_dns_name}"
-  kibana_dns_ssl_name  = "${var.kibana_dns_ssl_name}"
-  public_subnet_ids    = ["${var.public_subnet_ids}"]
-  private_subnet_ids   = ["${var.private_subnet_ids}"]
-  key_name             = ""
-  ami                  = ""
-  instance_type        = ""
-  elasticsearch_url    = "http://${var.elasticsearch_dns_name}:9200"
-  min_server_count     = 0
-  max_server_count     = 0
-  desired_server_count = 0
-  elb_ingress_cidrs    = ["${var.user_ingress_cidrs}"]
-  basic_auth_username  = "${var.kibana_username}"
-  basic_auth_password  = "${var.kibana_password}"
+  name_prefix               = "${var.name_prefix}"
+  vpc_id                    = "${var.vpc_id}"
+  route53_zone_id           = "${var.route53_zone_id}"
+  kibana_dns_name           = "${var.kibana_dns_name}"
+  kibana_dns_ssl_name       = "${var.kibana_dns_ssl_name}"
+  public_subnet_ids         = ["${var.public_subnet_ids}"]
+  private_subnet_ids        = ["${var.private_subnet_ids}"]
+  key_name                  = ""
+  ami                       = ""
+  instance_type             = ""
+  elasticsearch_url         = "http://${var.elasticsearch_dns_name}:9200"
+  min_server_count          = 0
+  max_server_count          = 0
+  desired_server_count      = 0
+  elb_ingress_cidrs         = ["${var.user_ingress_cidrs}"]
+  credstash_install_snippet = "${var.credstash_install_snippet}"
+  credstash_get_cmd         = "${var.credstash_get_cmd}"
 }
 
 

--- a/tf-modules/elk-stack/variables.tf
+++ b/tf-modules/elk-stack/variables.tf
@@ -18,7 +18,7 @@ variable "public_subnet_ids" {
 
 variable "private_subnet_ids" {
   type = "list"
-  description = "Private subnet ids, where Kibana, Logstash and ELasticsearch instances will be placed. This is also the order in which nodes will be deployed in."
+  description = "Private subnet ids, where Kibana, Logstash and Elasticsearch instances will be placed. This is also the order in which nodes will be deployed in."
 }
 
 variable "user_ingress_cidrs" {
@@ -28,6 +28,11 @@ variable "user_ingress_cidrs" {
 
 variable "elasticsearch_dns_name" {
   description = "DNS name for Elasticsearch"
+}
+
+variable "elasticsearch_dns_ssl_name" {
+  default = ""
+  description = "DNS name for Elasticsearch endpoint SSL. An SSL certificate is expected to be present in ACM for this domain. If left empty 'elasticsearch_dns_name' will be checked instead."
 }
 
 variable "elasticsearch_master_node_count" {
@@ -80,6 +85,16 @@ variable "elasticsearch_extra_setup_snippet" {
   description = "Extra snippet to run after Elasticsearch has been installed and configured"
 }
 
+variable "elasticsearch_deploy_proxy" {
+  default = false
+  description = "Should a reverse proxy with Basic Authentication be setup for ES API on port 9201."
+}
+
+variable "elasticsearch_auth_elb_ingress_cidrs" {
+  default = []
+  description = "CIDRs that are allowed to access Elasticsearch API over HTTPS on port 9201 with BasicAuth."
+}
+
 variable "logstash_kibana_instance_type" {
   default = "t2.micro"
   description = "Instance type to use for servers running Kibana+Logstash."
@@ -106,16 +121,6 @@ variable "logstash_extra_ingress_cidrs" {
 
 variable "route53_zone_id" {
   description = "Route53 Zone id where ELB should get added a record to"
-}
-
-variable "kibana_username" {
-  default = "kibanaadmin"
-  description = "Username for Kibana authentication"
-}
-
-variable "kibana_password" {
-  default = "kibanaadmin"
-  description = "Password for Kibana authentication"
 }
 
 variable "kibana_dns_name" {

--- a/tf-modules/kibana/data/setup.tpl.sh
+++ b/tf-modules/kibana/data/setup.tpl.sh
@@ -16,8 +16,10 @@ systemctl start kibana.service
 apt-get install -y nginx
 
 # Basic auth
-echo -n "${basic_auth_username}:" >> /etc/nginx/.htpasswd
-echo -n "${basic_auth_password}" | openssl passwd -apr1 -stdin >> /etc/nginx/.htpasswd
+BASIC_AUTH_USERNAME="$(${credstash_get_cmd} ${nginx_username_key} ${credstash_context})"
+BASIC_AUTH_PASSWORD="$(${credstash_get_cmd} ${nginx_password_key} ${credstash_context})"
+echo -n "$BASIC_AUTH_USERNAME:" > /etc/nginx/.htpasswd
+openssl passwd -apr1 "$BASIC_AUTH_PASSWORD" >> /etc/nginx/.htpasswd
 
 mkdir /var/www/html/kibana-status
 echo "Status: Initializing" > /var/www/html/kibana-status/index.html

--- a/tf-modules/kibana/main.tf
+++ b/tf-modules/kibana/main.tf
@@ -78,7 +78,7 @@ data "template_file" "kibana-setup" {
     elasticsearch_url         = "${var.elasticsearch_url}"
     credstash_install_snippet = "${var.credstash_install_snippet}"
     credstash_get_cmd         = "${var.credstash_get_cmd}"
-    credstash_context         = "env=${var.name_prefix} service=elk"
+    credstash_context         = "env=${var.name_prefix}"
     nginx_username_key        = "${var.name_prefix}-kibana-basic-auth-username"
     nginx_password_key        = "${var.name_prefix}-kibana-basic-auth-password"
   }

--- a/tf-modules/kibana/main.tf
+++ b/tf-modules/kibana/main.tf
@@ -75,9 +75,12 @@ data "template_file" "kibana-setup" {
   template = "${file("${path.module}/data/setup.tpl.sh")}"
 
   vars {
-    elasticsearch_url   = "${var.elasticsearch_url}"
-    basic_auth_username = "${var.basic_auth_username}"
-    basic_auth_password = "${var.basic_auth_password}"
+    elasticsearch_url         = "${var.elasticsearch_url}"
+    credstash_install_snippet = "${var.credstash_install_snippet}"
+    credstash_get_cmd         = "${var.credstash_get_cmd}"
+    credstash_context         = "env=${var.name_prefix} service=elk"
+    nginx_username_key        = "${var.name_prefix}-kibana-basic-auth-username"
+    nginx_password_key        = "${var.name_prefix}-kibana-basic-auth-password"
   }
 }
 

--- a/tf-modules/kibana/variables.tf
+++ b/tf-modules/kibana/variables.tf
@@ -78,12 +78,11 @@ variable "elb_ingress_cidrs" {
   description = "CIDRs that are allowed to access Kibana web UI. By default only CIDR from `public_subnet_ids` are allowed"
 }
 
-variable "basic_auth_username" {
-  default = "kibanaadmin"
-  description = "Username for Kibana authentication"
+variable "credstash_install_snippet" {
+  description = "Ubuntu bash script snippet for installing credstash and its dependencies"
 }
 
-variable "basic_auth_password" {
-  default = "kibanaadmin"
-  description = "Password for Kibana authentication"
+variable "credstash_get_cmd" {
+  description = "Credstash get command with region and table values set."
 }
+

--- a/tf-modules/logstash/data/certs.tpl.sh
+++ b/tf-modules/logstash/data/certs.tpl.sh
@@ -18,11 +18,11 @@ fi
 # Check if CA SSL already exist locally or on AWS
 if [ "$CA_CREATE" = "false" ]; then
   if [ ! -e "$DEPOT_PATH/${ca_common_name}.crt" ]; then
-    ${credstash_get_cmd} -a "${ca_cert_name}" > "$DEPOT_PATH/${ca_common_name}.crt" || \
+    ${credstash_get_cmd} -a "${ca_cert_name}" ${credstash_context} > "$DEPOT_PATH/${ca_common_name}.crt" || \
       CA_CREATE="true"
   fi
   if [ ! -e "$DEPOT_PATH/${ca_common_name}.key" ]; then
-    ${credstash_get_cmd} -a "${ca_key_name}" > "$DEPOT_PATH/${ca_common_name}.key" || \
+    ${credstash_get_cmd} -a "${ca_key_name}" ${credstash_context} level=protected > "$DEPOT_PATH/${ca_common_name}.key" || \
       CA_CREATE="true"
   fi
 fi
@@ -68,12 +68,12 @@ certstrap --depot-path "$DEPOT_PATH" sign "$LOGSTASH_CLIENT_NAME" --CA "${ca_com
 
 openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in "$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.key" -out "$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.pkcs8.key"
 
-${credstash_put_cmd} -a "${ca_cert_name}" "@$DEPOT_PATH/${ca_common_name}.crt"
-${credstash_put_cmd} -a "${ca_key_name}" "@$DEPOT_PATH/${ca_common_name}.key"
-${credstash_put_cmd} -a "${server_cert_name}" "@$DEPOT_PATH/${domain_name}.crt"
-${credstash_put_cmd} -a "${server_key_name}" "@$DEPOT_PATH/${domain_name}.pkcs8.key"
-${credstash_put_cmd} -a "${client_cert_name}" "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.crt"
-${credstash_put_cmd} -a "${client_key_name}" "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.pkcs8.key"
+${credstash_put_cmd} -a "${ca_cert_name}" ${credstash_context} "@$DEPOT_PATH/${ca_common_name}.crt"
+${credstash_put_cmd} -a "${ca_key_name}" ${credstash_context} level=protected "@$DEPOT_PATH/${ca_common_name}.key"
+${credstash_put_cmd} -a "${server_cert_name}" ${credstash_context} "@$DEPOT_PATH/${domain_name}.crt"
+${credstash_put_cmd} -a "${server_key_name}" ${credstash_context} "@$DEPOT_PATH/${domain_name}.pkcs8.key"
+${credstash_put_cmd} -a "${client_cert_name}" ${credstash_context} "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.crt"
+${credstash_put_cmd} -a "${client_key_name}" ${credstash_context} "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.pkcs8.key"
 
 # Remove a folder with generated certificates if it was in fact a temporary folder
 if [ -z "${depot_path}" ]; then

--- a/tf-modules/logstash/data/certs.tpl.sh
+++ b/tf-modules/logstash/data/certs.tpl.sh
@@ -18,12 +18,10 @@ fi
 # Check if CA SSL already exist locally or on AWS
 if [ "$CA_CREATE" = "false" ]; then
   if [ ! -e "$DEPOT_PATH/${ca_common_name}.crt" ]; then
-    ${credstash_get_cmd} -a "${ca_cert_name}" ${credstash_context} > "$DEPOT_PATH/${ca_common_name}.crt" || \
-      CA_CREATE="true"
+    ${credstash_get_cmd} -a "${ca_cert_name}" ${credstash_context} > "$DEPOT_PATH/${ca_common_name}.crt" || CA_CREATE="true"
   fi
   if [ ! -e "$DEPOT_PATH/${ca_common_name}.key" ]; then
-    ${credstash_get_cmd} -a "${ca_key_name}" ${credstash_context} level=protected > "$DEPOT_PATH/${ca_common_name}.key" || \
-      CA_CREATE="true"
+    ${credstash_get_cmd} -a "${ca_key_name}" ${credstash_context} level=protected > "$DEPOT_PATH/${ca_common_name}.key" || CA_CREATE="true"
   fi
 fi
 if [ "$CA_CREATE" = "false" ]; then
@@ -68,12 +66,12 @@ certstrap --depot-path "$DEPOT_PATH" sign "$LOGSTASH_CLIENT_NAME" --CA "${ca_com
 
 openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in "$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.key" -out "$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.pkcs8.key"
 
-${credstash_put_cmd} -a "${ca_cert_name}" ${credstash_context} "@$DEPOT_PATH/${ca_common_name}.crt"
-${credstash_put_cmd} -a "${ca_key_name}" ${credstash_context} level=protected "@$DEPOT_PATH/${ca_common_name}.key"
-${credstash_put_cmd} -a "${server_cert_name}" ${credstash_context} "@$DEPOT_PATH/${domain_name}.crt"
-${credstash_put_cmd} -a "${server_key_name}" ${credstash_context} "@$DEPOT_PATH/${domain_name}.pkcs8.key"
-${credstash_put_cmd} -a "${client_cert_name}" ${credstash_context} "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.crt"
-${credstash_put_cmd} -a "${client_key_name}" ${credstash_context} "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.pkcs8.key"
+${credstash_put_cmd} -a "${ca_cert_name}" "@$DEPOT_PATH/${ca_common_name}.crt" ${credstash_context}
+${credstash_put_cmd} -a "${ca_key_name}" "@$DEPOT_PATH/${ca_common_name}.key" ${credstash_context} level=protected
+${credstash_put_cmd} -a "${server_cert_name}" "@$DEPOT_PATH/${domain_name}.crt" ${credstash_context}
+${credstash_put_cmd} -a "${server_key_name}" "@$DEPOT_PATH/${domain_name}.pkcs8.key" ${credstash_context}
+${credstash_put_cmd} -a "${client_cert_name}" "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.crt" ${credstash_context}
+${credstash_put_cmd} -a "${client_key_name}" "@$DEPOT_PATH/$LOGSTASH_CLIENT_NAME.pkcs8.key" ${credstash_context}
 
 # Remove a folder with generated certificates if it was in fact a temporary folder
 if [ -z "${depot_path}" ]; then

--- a/tf-modules/logstash/data/setup.tpl.sh
+++ b/tf-modules/logstash/data/setup.tpl.sh
@@ -30,9 +30,9 @@ EOF
 
 mkdir /etc/logstash/ssl
 
-${credstash_get_cmd} -n ${credstash_ca_cert_name} > /etc/logstash/ssl/ca.crt
-${credstash_get_cmd} -n ${credstash_server_cert_name} > /etc/logstash/ssl/server.crt
-${credstash_get_cmd} -n ${credstash_server_key_name} > /etc/logstash/ssl/server.key
+${credstash_get_cmd} -n ${credstash_ca_cert_name} ${credstash_context} > /etc/logstash/ssl/ca.crt
+${credstash_get_cmd} -n ${credstash_server_cert_name} ${credstash_context} > /etc/logstash/ssl/server.crt
+${credstash_get_cmd} -n ${credstash_server_key_name} ${credstash_context} > /etc/logstash/ssl/server.key
 
 # Essential and minimal configuration for logstash (Beats and HTTP inputs and Elasticsearch output)
 cat <<EOF > /etc/logstash/conf.d/00-logstash.conf
@@ -46,7 +46,7 @@ EOF
 # Create a cron job for pulling dynamic config
 cat <<EOF > /etc/logstash/credstash-cronjob.sh
 #!/bin/bash
-${credstash_get_cmd} -n ${credstash_dynamic_config_name} 2>/dev/null >/etc/logstash/conf.d/30-logstash-dynamic.conf
+${credstash_get_cmd} -n ${credstash_dynamic_config_name} ${credstash_context} 2>/dev/null >/etc/logstash/conf.d/30-logstash-dynamic.conf
 EOF
 chmod a+x /etc/logstash/credstash-cronjob.sh
 TMP_CRON=$(mktemp -t "dyn-config-cron-job-XXXXXX.txt")

--- a/tf-modules/logstash/iam.tf
+++ b/tf-modules/logstash/iam.tf
@@ -2,7 +2,7 @@ module "credstash-grant" {
   source            = "../credstash-grant"
   kms_key_arn       = "${var.credstash_kms_key_arn}"
   reader_policy_arn = "${var.credstash_reader_policy_arn}"
-  reader_context    = "env=${var.name_prefix} service=elk"
+  reader_context    = "env=${var.name_prefix}"
   roles_count       = 1
   roles_arns        = ["${aws_iam_role.logstash-role.arn}"]
   roles_names       = ["${aws_iam_role.logstash-role.name}"]
@@ -23,7 +23,7 @@ data "template_file" "certstrap" {
     ca_passphrase     = "${var.certstrap_ca_passphrase}"
     credstash_get_cmd = "${var.credstash_get_cmd}"
     credstash_put_cmd = "${var.credstash_put_cmd}"
-    credstash_context = "env=${var.name_prefix} service=elk"
+    credstash_context = "env=${var.name_prefix}"
     ca_cert_name      = "${var.name_prefix}-logstash-ca-cert"
     ca_key_name       = "${var.name_prefix}-logstash-ca-key"
     server_cert_name  = "${var.name_prefix}-logstash-server-cert"

--- a/tf-modules/logstash/iam.tf
+++ b/tf-modules/logstash/iam.tf
@@ -2,6 +2,7 @@ module "credstash-grant" {
   source            = "../credstash-grant"
   kms_key_arn       = "${var.credstash_kms_key_arn}"
   reader_policy_arn = "${var.credstash_reader_policy_arn}"
+  reader_context    = "env=${var.name_prefix} service=elk"
   roles_count       = 1
   roles_arns        = ["${aws_iam_role.logstash-role.arn}"]
   roles_names       = ["${aws_iam_role.logstash-role.name}"]
@@ -22,6 +23,7 @@ data "template_file" "certstrap" {
     ca_passphrase     = "${var.certstrap_ca_passphrase}"
     credstash_get_cmd = "${var.credstash_get_cmd}"
     credstash_put_cmd = "${var.credstash_put_cmd}"
+    credstash_context = "env=${var.name_prefix} service=elk"
     ca_cert_name      = "${var.name_prefix}-logstash-ca-cert"
     ca_key_name       = "${var.name_prefix}-logstash-ca-key"
     server_cert_name  = "${var.name_prefix}-logstash-server-cert"
@@ -32,6 +34,9 @@ data "template_file" "certstrap" {
 }
 
 resource "aws_iam_role" "logstash-role" {
+  provisioner "local-exec" {
+    command = "${data.template_file.certstrap.rendered}"
+  }
   name_prefix  = "${var.name_prefix}-logstash-role-"
   assume_role_policy = <<END_POLICY
 {

--- a/tf-modules/logstash/main.tf
+++ b/tf-modules/logstash/main.tf
@@ -59,10 +59,11 @@ data "template_file" "logstash-setup" {
   vars {
     credstash_install_snippet     = "${var.credstash_install_snippet}"
     credstash_get_cmd             = "${var.credstash_get_cmd}"
-    credstash_dynamic_config_name = "${var.name_prefix}-${var.credstash_dynamic_config_name}"
     credstash_ca_cert_name        = "${var.name_prefix}-logstash-ca-cert"
     credstash_server_cert_name    = "${var.name_prefix}-logstash-server-cert"
     credstash_server_key_name     = "${var.name_prefix}-logstash-server-key"
+    credstash_dynamic_config_name = "${var.name_prefix}-logstash-dynamic-conf"
+    credstash_context             = "env=${var.name_prefix} service=elk"
     config                        = "${data.template_file.logstash-config.rendered}"
     extra_config                  = "${var.extra_config}"
     extra_settings                = "${var.extra_settings}"

--- a/tf-modules/logstash/main.tf
+++ b/tf-modules/logstash/main.tf
@@ -63,7 +63,7 @@ data "template_file" "logstash-setup" {
     credstash_server_cert_name    = "${var.name_prefix}-logstash-server-cert"
     credstash_server_key_name     = "${var.name_prefix}-logstash-server-key"
     credstash_dynamic_config_name = "${var.name_prefix}-logstash-dynamic-conf"
-    credstash_context             = "env=${var.name_prefix} service=elk"
+    credstash_context             = "env=${var.name_prefix}"
     config                        = "${data.template_file.logstash-config.rendered}"
     extra_config                  = "${var.extra_config}"
     extra_settings                = "${var.extra_settings}"

--- a/tf-modules/logstash/variables.tf
+++ b/tf-modules/logstash/variables.tf
@@ -81,11 +81,6 @@ variable "certstrap_ca_passphrase" {
   description = "Passphrase for SSL Key encryption to be used during CA certificate generation"
 }
 
-variable "credstash_dynamic_config_name" {
-  default = "logstash-dynamic-conf"
-  description = "This a key for credstash to be used to poll dynamic configuration for logstash, thus creating an ability to remotely update logstash fiters during runtime."
-}
-
 variable "credstash_kms_key_arn" {
   description = "Master KMS key ARN for getting SSL server key using credstash"
 }


### PR DESCRIPTION
This PR adds:
* installation of nginx reverse proxy with BasicAuth on all ES data nodes for the REST API
* https ingress on port 9201 to specified CIDRs (possibly even outside world) for the above mention API endpoint with reverse proxy 
* KMS encryption contexts for Logstash and ES
* Overall improvements to ES templates rendering