### PR TITLE
Extracted Route53 attachments into separate module for ELK componenets

### DIFF
--- a/tf-modules/elasticsearch/data-nodes.tf
+++ b/tf-modules/elasticsearch/data-nodes.tf
@@ -167,16 +167,3 @@ resource "aws_elb" "elasticsearch-elb" {
   connection_draining       = false
 
 }
-
-
-resource "aws_route53_record" "elasticsearch-elb" {
-  zone_id = "${var.route53_zone_id}"
-  name = "${var.elasticsearch_dns_name}"
-  type = "A"
-
-  alias {
-    name = "${aws_elb.elasticsearch-elb.dns_name}"
-    zone_id = "${aws_elb.elasticsearch-elb.zone_id}"
-    evaluate_target_health = true
-  }
-}

--- a/tf-modules/elasticsearch/outputs.tf
+++ b/tf-modules/elasticsearch/outputs.tf
@@ -1,7 +1,3 @@
-output "elb_dns" {
-  value = "${aws_elb.elasticsearch-elb.dns_name}"
-}
-
 output "master_node_asg_names" {
   value = ["${aws_autoscaling_group.master-node-asg.*.name}"]
 }
@@ -16,4 +12,12 @@ output "master_node_ebs_volume_ids" {
 
 output "data_node_ebs_volume_ids" {
   value = ["${module.data-node-ebs-volumes.volume_ids}"]
+}
+
+output "elasticsearch_dns" {
+  value = {
+    "dns_name"     = "${var.elasticsearch_dns_name}"
+    "elb_dns_name" = "${aws_elb.elasticsearch-elb.dns_name}"
+    "elb_zone_id"  = "${aws_elb.elasticsearch-elb.zone_id}"
+  }
 }

--- a/tf-modules/elasticsearch/variables.tf
+++ b/tf-modules/elasticsearch/variables.tf
@@ -90,10 +90,6 @@ variable "internal" {
   description = "Set it to false if you want Elasticsearch to be accessible by the outside world"
 }
 
-variable "route53_zone_id" {
-  description = "Route53 Zone id where ELB should get added a record to"
-}
-
 variable "elasticsearch_dns_name" {
   description = "DNS name for Elasticsearch"
 }

--- a/tf-modules/elk-r53/main.tf
+++ b/tf-modules/elk-r53/main.tf
@@ -1,0 +1,39 @@
+/** This module adds all domain names to the Hosted Zone
+ *  with an A Alias to their respective ELBs
+**/
+
+resource "aws_route53_record" "elasticsearch-elb" {
+  zone_id = "${var.route53_zone_id}"
+  name    = "${var.elasticsearch["dns_name"]}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.elasticsearch["elb_dns_name"]}"
+    zone_id                = "${var.elasticsearch["elb_zone_id"]}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "logstash-elb" {
+  zone_id = "${var.route53_zone_id}"
+  name    = "${var.logstash["dns_name"]}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.logstash["elb_dns_name"]}"
+    zone_id                = "${var.logstash["elb_zone_id"]}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "kibana-elb" {
+  zone_id = "${var.route53_zone_id}"
+  name    = "${var.kibana["dns_name"]}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.kibana["elb_dns_name"]}"
+    zone_id                = "${var.kibana["elb_zone_id"]}"
+    evaluate_target_health = true
+  }
+}

--- a/tf-modules/elk-r53/variables.tf
+++ b/tf-modules/elk-r53/variables.tf
@@ -1,0 +1,38 @@
+variable "route53_zone_id" {
+  description = "Route53 Zone id where records for ELBs will be added to"
+}
+
+# Example:
+# elasticsearch = {
+#    "dns_name"     = "elasticsearch.example.com"
+#    "elb_dns_name" = "${aws_elb.elasticsearch-elb.dns_name}"
+#    "elb_zone_id"  = "${aws_elb.elasticsearch-elb.zone_id}"
+#  }
+variable "elasticsearch" {
+  description = "Elasticsearch DNS and ELB info"
+  type = "map"
+}
+
+
+# Example:
+# logstash = {
+#    "dns_name"     = "logstash.example.com"
+#    "elb_dns_name" = "${aws_elb.logstash-elb.dns_name}"
+#    "elb_zone_id"  = "${aws_elb.logstash-elb.zone_id}"
+#  }
+variable "logstash" {
+  description = "Logstash DNS and ELB info"
+  type = "map"
+}
+
+
+# Example:
+# kibana = {
+#    "dns_name"     = "kibana.example.com"
+#    "elb_dns_name" = "${aws_elb.kibana-elb.dns_name}"
+#    "elb_zone_id"  = "${aws_elb.kibana-elb.zone_id}"
+#  }
+variable "kibana" {
+  description = "Kibana DNS and ELB info"
+  type = "map"
+}

--- a/tf-modules/elk-stack/main.tf
+++ b/tf-modules/elk-stack/main.tf
@@ -58,7 +58,6 @@ module "elasticsearch" {
 
   name_prefix                 = "${var.name_prefix}"
   vpc_id                      = "${var.vpc_id}"
-  route53_zone_id             = "${var.route53_zone_id}"
   key_name                    = "${var.ssh_key_name}"
   public_subnet_ids           = ["${var.private_subnet_ids}"]
   private_subnet_ids          = ["${var.private_subnet_ids}"]
@@ -91,7 +90,6 @@ module "kibana" {
 
   name_prefix               = "${var.name_prefix}"
   vpc_id                    = "${var.vpc_id}"
-  route53_zone_id           = "${var.route53_zone_id}"
   kibana_dns_name           = "${var.kibana_dns_name}"
   kibana_dns_ssl_name       = "${var.kibana_dns_ssl_name}"
   public_subnet_ids         = ["${var.public_subnet_ids}"]
@@ -117,7 +115,6 @@ module "logstash-kibana" {
   vpc_id                      = "${var.vpc_id}"
   public_subnet_ids           = ["${var.public_subnet_ids}"]
   private_subnet_ids          = ["${var.private_subnet_ids}"]
-  route53_zone_id             = "${var.route53_zone_id}"
   logstash_dns_name           = "${var.logstash_dns_name}"
   ami                         = "${data.aws_ami.ubuntu.id}"
   instance_type               = "${var.logstash_kibana_instance_type}"

--- a/tf-modules/elk-stack/output.tf
+++ b/tf-modules/elk-stack/output.tf
@@ -27,3 +27,11 @@ output "elasticsearch_data_node_ebs_volume_ids" {
 output "logstash_kibana_asg_name" {
   value = "${module.logstash-kibana.asg_name}"
 }
+
+output "dns" {
+  value = {
+    "elasticsearch" = "${module.elasticsearch.elasticsearch_dns}"
+    "logstash" = "${module.logstash-kibana.logstash_dns}"
+    "kibana" = "${module.kibana.kibana_dns}"
+  }
+}

--- a/tf-modules/elk-stack/variables.tf
+++ b/tf-modules/elk-stack/variables.tf
@@ -133,10 +133,6 @@ variable "logstash_dns_name" {
   description = "DNS name for Logstash"
 }
 
-variable "route53_zone_id" {
-  description = "Route53 Zone id where ELB should get added a record to"
-}
-
 variable "kibana_dns_name" {
   description = "DNS name for Kibana"
 }

--- a/tf-modules/kibana/main.tf
+++ b/tf-modules/kibana/main.tf
@@ -58,19 +58,6 @@ resource "aws_elb" "kibana-elb" {
 }
 
 
-resource "aws_route53_record" "kibana-elb" {
-  zone_id = "${var.route53_zone_id}"
-  name = "${var.kibana_dns_name}"
-  type = "A"
-
-  alias {
-    name = "${aws_elb.kibana-elb.dns_name}"
-    zone_id = "${aws_elb.kibana-elb.zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-
 data "template_file" "kibana-setup" {
   template = "${file("${path.module}/data/setup.tpl.sh")}"
 

--- a/tf-modules/kibana/outputs.tf
+++ b/tf-modules/kibana/outputs.tf
@@ -1,11 +1,3 @@
-output "elb_dns" {
-  value = "${aws_elb.kibana-elb.dns_name}"
-}
-
-output "elb_name" {
-  value = "${aws_elb.kibana-elb.name}"
-}
-
 output "security_group_id" {
   value = "${aws_security_group.kibana-sg.id}"
 }
@@ -16,4 +8,15 @@ output "setup_snippet" {
 
 output "asg_name" {
   value = "${aws_autoscaling_group.kibana-asg.name}"
+}
+
+output "elb_name" {
+  value = "${aws_elb.kibana-elb.name}"
+}
+output "kibana_dns" {
+  value = {
+    "dns_name"     = "${var.kibana_dns_name}"
+    "elb_dns_name" = "${aws_elb.kibana-elb.dns_name}"
+    "elb_zone_id"  = "${aws_elb.kibana-elb.zone_id}"
+  }
 }

--- a/tf-modules/kibana/variables.tf
+++ b/tf-modules/kibana/variables.tf
@@ -46,10 +46,6 @@ variable "kibana_dns_ssl_name" {
   description = "DNS name for Kibana endpoint SSL. An SSL certificate is expected to be present in ACM for this domain. If left empty 'kibana_dns_name' will be checked instead."
 }
 
-variable "route53_zone_id" {
-  description = "Route53 Zone id where ELB should get added a record to"
-}
-
 variable "elasticsearch_url" {
   description = "Elasticsearch endpoint URL"
 }

--- a/tf-modules/logstash/main.tf
+++ b/tf-modules/logstash/main.tf
@@ -40,18 +40,6 @@ resource "aws_elb" "logstash-elb" {
 }
 
 
-resource "aws_route53_record" "logstash-elb" {
-  zone_id = "${var.route53_zone_id}"
-  name    = "${var.logstash_dns_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_elb.logstash-elb.dns_name}"
-    zone_id                = "${aws_elb.logstash-elb.zone_id}"
-    evaluate_target_health = true
-  }
-}
-
 
 data "template_file" "logstash-setup" {
   template = "${file("${path.module}/data/setup.tpl.sh")}"

--- a/tf-modules/logstash/outputs.tf
+++ b/tf-modules/logstash/outputs.tf
@@ -1,7 +1,3 @@
-output "elb_dns" {
-  value = "${aws_elb.logstash-elb.dns_name}"
-}
-
 output "elb_name" {
   value = "${aws_elb.logstash-elb.name}"
 }
@@ -12,4 +8,12 @@ output "logstash_role_name" {
 
 output "asg_name" {
   value = "${aws_autoscaling_group.logstash-asg.name}"
+}
+
+output "logstash_dns" {
+  value = {
+    "dns_name"     = "${var.logstash_dns_name}"
+    "elb_dns_name" = "${aws_elb.logstash-elb.dns_name}"
+    "elb_zone_id"  = "${aws_elb.logstash-elb.zone_id}"
+  }
 }

--- a/tf-modules/logstash/variables.tf
+++ b/tf-modules/logstash/variables.tf
@@ -49,10 +49,6 @@ variable "logstash_dns_name" {
   description = "DNS name for Logstash endpoint"
 }
 
-variable "route53_zone_id" {
-  description = "Route53 Zone id where ELB should get added a record to"
-}
-
 variable "elasticsearch_url" {
   description = "Elasticsearch endpoint url"
 }


### PR DESCRIPTION
ELK will assume that DNS records created in some other way if Route53 isn't used