### PR TITLE
Fixed syntax errors in consul-leader-wan-sg

### DIFF
--- a/tf-modules/consul-leader-wan-sg/main.tf
+++ b/tf-modules/consul-leader-wan-sg/main.tf
@@ -9,22 +9,25 @@
  *
  */
 resource "aws_security_group" "main" {
-    vpc_id = "${var.vpc_id}"
-    tags {
-        Name = "${var.name}-consul-leader-wan"
-        Description = "Allow TCP and UDP to WAN port (${var.wan_port}) for consul leaders in ${var.name}"
-    }
-    # Serf WAN, used by servers to gossip over the WAN to other servers. TCP and UDP.
-    ingress {
-        from_port = ${var.wan_port}
-        to_port = ${var.wan_port}
-        protocol = "tcp"
-        cidr_blocks = ["${split(",", replace(var.cidr_blocks, " ", ""))}"]
-    }
-    ingress {
-        from_port = ${var.wan_port}
-        to_port = ${var.wan_port}
-        protocol = "udp"
-        cidr_blocks = ["${split(",", replace(var.cidr_blocks, " ", ""))}"]
-    }
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name        = "${var.name}-consul-leader-wan"
+    Description = "Allow TCP and UDP to WAN port (${var.wan_port}) for consul leaders in ${var.name}"
+  }
+
+  # Serf WAN, used by servers to gossip over the WAN to other servers. TCP and UDP.
+  ingress {
+    from_port   = "${var.wan_port}"
+    to_port     = "${var.wan_port}"
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", replace(var.cidr_blocks, " ", ""))}"]
+  }
+
+  ingress {
+    from_port   = "${var.wan_port}"
+    to_port     = "${var.wan_port}"
+    protocol    = "udp"
+    cidr_blocks = ["${split(",", replace(var.cidr_blocks, " ", ""))}"]
+  }
 }


### PR DESCRIPTION
This fixes the syntax errors on lines 19, 20, 25 and 26 and runs `terraform fmt` to provide evidence that it works now.