### PR TITLE
Corrected outputs in the aws-ipsec-vpn and subnets modules

### DIFF
--- a/tf-modules/aws-ipsec-vpn/outputs.tf
+++ b/tf-modules/aws-ipsec-vpn/outputs.tf
@@ -39,7 +39,7 @@ output "vpn_config" {
 }
 // List of destination CIDR blocks, one for each (static) VPN Connection Route
 output "vpn_connection_static_routes" {
-  value = ["${aws_vpn_connection_route.main.*.destination_cide_block}"]
+  value = ["${aws_vpn_connection_route.main.*.destination_cidr_block}"]
 }
 
 

--- a/tf-modules/subnets/output.tf
+++ b/tf-modules/subnets/output.tf
@@ -10,7 +10,7 @@ output "cidr_blocks" {
 
 // list of Availability Zones
 output "azs" {
-  value = ["${aws_subnet.main.*.availability_zones}"]
+  value = ["${aws_subnet.main.*.availability_zone}"]
 }
 
 // ID of the VPC the subnets are in


### PR DESCRIPTION
Updating to Terraform v0.11.0 reveals some broken (and presumably previously-unused outputs)