### PR TITLE
Changes to gitlab-related modules

### DIFF
--- a/tests/gitlab-asg/main.tf
+++ b/tests/gitlab-asg/main.tf
@@ -16,7 +16,7 @@ variable "key_file" {
 }
 
 module "setup" {
-  name               = "test"
+  name_prefix        = "test"
   source             = "../../tf-modules/gitlab-single-node-asg"
   region             = "${var.region}"
   az                 = "${var.az}"

--- a/tf-modules/gitlab-single-node-asg/main.tf
+++ b/tf-modules/gitlab-single-node-asg/main.tf
@@ -1,8 +1,8 @@
-/** 
+/**
  * Run a Gitlab on a single EC2 instance.
  * This instance will be part of a single-node autoscaling group
  * that shares an EBS volume to store data.
- * 
+ *
  * Note that there is a peculiarity with the EBS volume in that it
  * requires some manual setup the very first time to make it available
  * for use (unless a snapshot id is supplied):
@@ -19,10 +19,9 @@
 
 module "gitlab-asg" {
   source                  = "../single-node-asg"
-  name                    = "${var.name}"
+  name                    = "${var.name_prefix}"
   az                      = "${var.az}"
   key_name                = "${var.key_name}"
-  key_file                = "${var.key_file}"
   ami                     = "${var.instance_ami}"
   instance_type           = "${var.instance_type}"
   name_suffix             = "gitlab-asg"
@@ -37,6 +36,7 @@ module "gitlab-asg" {
   data_volume_kms_key_id  = "${var.data_volume_kms_key_id}"
   data_volume_snapshot_id = "${var.data_volume_snapshot_id}"
   data_volume_iops        = "${var.data_volume_iops}"
+  aws_cloud               = "${var.aws_cloud}"
 
   init_prefix = <<END_INIT
 apt-get update

--- a/tf-modules/gitlab-single-node-asg/variables.tf
+++ b/tf-modules/gitlab-single-node-asg/variables.tf
@@ -1,5 +1,5 @@
-variable "name" {
-  description = "The name of the autoscaling group"
+variable "name_prefix" {
+  description = "The name prefix of the autoscaling group"
 }
 
 variable "key_name" {
@@ -27,10 +27,6 @@ variable "region" {
 
 variable "az" {
   description = "The availability zone to create the instance in"
-}
-
-variable "key_file" {
-  description = "Path to the SSH private key to provide connection info as output"
 }
 
 variable "vpc_id" {
@@ -94,4 +90,9 @@ variable "gitlab_http_port" {
 variable "gitlab_https_port" {
   default     = "443"
   description = "The port to use for https access to the gitlab instance"
+}
+
+variable "aws_cloud" {
+  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
+  default     = "aws"
 }

--- a/tf-modules/single-node-asg/outputs.tf
+++ b/tf-modules/single-node-asg/outputs.tf
@@ -1,7 +1,3 @@
-//Export the `key_file` variable for convenience
-output "key_file" {
-    value = "${var.key_file}"
-}
 //`name` exported from the Server `aws_autoscaling_group`
 output "asg_name" {
     value = "${module.server.name}"

--- a/tf-modules/single-node-asg/variables.tf
+++ b/tf-modules/single-node-asg/variables.tf
@@ -4,9 +4,6 @@ variable "name" {
 variable "key_name" {
   description = "The name of the (AWS) SSH key to associate with the instance"
 }
-variable "key_file" {
-  description = "Path to the SSH private key to provide connection info as output"
-}
 variable "ami" {
   description = "The base AMI for each AWS instance created"
 }
@@ -81,3 +78,4 @@ variable "aws_cloud" {
   description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
   default     = "aws"
 }
+


### PR DESCRIPTION
* Removed 'key_file' param and changed 'name' param to 'name_prefix' in the 'single-node-asg', 'gitlab-single-node-asg', and 'tests/gitlab-asg' modules.
* Added 'aws_cloud' param to the 'gitlab-single-node-asg' module.