### PR TITLE
Cloudtrail logs

### DIFF
--- a/tf-modules/cloudtrail/main.tf
+++ b/tf-modules/cloudtrail/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "cloudtrail-bucket" {
     }
 
     actions   = ["s3:GetBucketAcl"]
-    resources = ["arn:${var.aws_cloud}:::${var.name_prefix}-cloudtrail"]
+    resources = ["arn:${var.aws_cloud}:s3:::${var.name_prefix}-cloudtrail"]
   }
 
   statement {
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "cloudtrail-bucket" {
     }
 
     actions   = ["s3:PutObject"]
-    resources = ["arn:${var.aws_cloud}:::${var.name_prefix}-cloudtrail/*"]
+    resources = ["arn:${var.aws_cloud}:s3:::${var.name_prefix}-cloudtrail/*"]
 
     condition {
       test     = "StringEquals"

--- a/tf-modules/cloudtrail/main.tf
+++ b/tf-modules/cloudtrail/main.tf
@@ -1,6 +1,7 @@
 resource "aws_cloudtrail" "cloudtrail" {
   name           = "${var.name_prefix}-cloudtrail"
   s3_bucket_name = "${aws_s3_bucket.cloudtrail.id}"
+  kms_key_id     = "${var.kms_key_id}"
 
   include_global_service_events = "${var.include_global_service_events}"
   enable_logging                = "${var.enable_logging}"

--- a/tf-modules/cloudtrail/main.tf
+++ b/tf-modules/cloudtrail/main.tf
@@ -12,10 +12,15 @@ resource "aws_cloudtrail" "cloudtrail" {
 
 resource "aws_s3_bucket" "cloudtrail" {
   bucket = "${var.name_prefix}-cloudtrail"
+  region = "${data.aws_region.current.name}"
   acl    = "private"
   policy = "${data.aws_iam_policy_document.cloudtrail-bucket.json}"
 
   tags = "${merge(map("Name", "${var.name_prefix}-cloudtrail"), "${var.extra_tags}")}"
+}
+
+data "aws_region" "current" {
+  current = true
 }
 
 data "aws_iam_policy_document" "cloudtrail-bucket" {

--- a/tf-modules/cloudtrail/main.tf
+++ b/tf-modules/cloudtrail/main.tf
@@ -1,0 +1,52 @@
+resource "aws_cloudtrail" "cloudtrail" {
+  name           = "${var.name_prefix}-cloudtrail"
+  s3_bucket_name = "${aws_s3_bucket.cloudtrail.id}"
+
+  include_global_service_events = "${var.include_global_service_events}"
+  enable_logging                = "${var.enable_logging}"
+  is_multi_region_trail         = false
+
+  tags = "${merge(map("Name", "${var.name_prefix}-cloudtrail"), "${var.extra_tags}")}"
+}
+
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket = "${var.name_prefix}-cloudtrail"
+  acl    = "private"
+  policy = "${data.aws_iam_policy_document.cloudtrail-bucket.json}"
+
+  tags = "${merge(map("Name", "${var.name_prefix}-cloudtrail"), "${var.extra_tags}")}"
+}
+
+data "aws_iam_policy_document" "cloudtrail-bucket" {
+  statement {
+    sid    = "AWSCloudTrailAclCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["arn:${var.aws_cloud}:::${var.name_prefix}-cloudtrail"]
+  }
+
+  statement {
+    sid    = "AWSCloudTrailWrite"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["arn:${var.aws_cloud}:::${var.name_prefix}-cloudtrail/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}

--- a/tf-modules/cloudtrail/outputs.tf
+++ b/tf-modules/cloudtrail/outputs.tf
@@ -1,0 +1,19 @@
+output "cloudtrail_id" {
+  value = "${aws_cloudtrail.cloudtrail.id}"
+}
+
+output "cloudtrail_home_region" {
+  value = "${aws_cloudtrail.cloudtrail.home_region}"
+}
+
+output "cloudtrail_arn" {
+  value = "${aws_cloudtrail.cloudtrail.arn}"
+}
+
+output "s3_bucket_id" {
+  value = "${aws_s3_bucket.cloudtrail.id}"
+}
+
+output "s3_bucket_arn" {
+  value = "${aws_s3_bucket.cloudtrail.arn}"
+}

--- a/tf-modules/cloudtrail/variables.tf
+++ b/tf-modules/cloudtrail/variables.tf
@@ -1,0 +1,22 @@
+variable "name_prefix" {
+  description = "name to be prepended to all resources"
+}
+
+variable "aws_cloud" {
+  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
+  default     = "aws"
+}
+
+variable "include_global_service_events" {
+  description = "boolean, if true logs IAM events as well as region-specific ones"
+  default     = true
+}
+
+variable "enable_logging" {
+  description = "boolean, defines if logging should be started or stopped"
+  default     = true
+}
+
+variable "extra_tags" {
+  default = {}
+}

--- a/tf-modules/cloudtrail/variables.tf
+++ b/tf-modules/cloudtrail/variables.tf
@@ -7,6 +7,11 @@ variable "aws_cloud" {
   default     = "aws"
 }
 
+variable "kms_key_id" {
+  description = "KMS key ARN for encryption of logs"
+  default     = ""
+}
+
 variable "include_global_service_events" {
   description = "boolean, if true logs IAM events as well as region-specific ones"
   default     = true

--- a/tf-modules/cloudtrail/variables.tf
+++ b/tf-modules/cloudtrail/variables.tf
@@ -18,7 +18,7 @@ variable "include_global_service_events" {
 }
 
 variable "enable_logging" {
-  description = "boolean, defines if logging should be started or stopped"
+  description = "boolean, maps to `aws_cloudtrail`'s enable_logging parameter"
   default     = true
 }
 


### PR DESCRIPTION
Adds a `cloudtrail` module that creates a S3 bucket and sends CloudTrail logs towards it for the current region. Since `aws_cloudtrail` resources on Terraform use the currently active region, S3 buckets default to using callee’s. This module includes policies for writing out to the bucket as `data.aws_iam_policy_document` to ensure (as much as possible) compile-time verification.

Optionally, if user provides `kms_key_arn` contents are encrypted.